### PR TITLE
更新配置文件获取路径

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -12,7 +12,7 @@ class ServiceProvider extends LaravelServiceProvider
     public function register()
     {
         $this->app->singleton(SocialiteManager::class, function () {
-            $config = array_merge(\config('socialite', []), \config('services', []));
+            $config = array_merge(\config('socialite', []), \config('services.socialite', []));
 
             return new SocialiteManager($config);
         });


### PR DESCRIPTION
Services 配置文件中包含很多第三方的配置信息，使用 socialite 做二次定位会更合理清晰，不会和其他配置混淆。